### PR TITLE
With https://github.com/stephenwvickers/node-raw-socket/pull/11

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ The `createSession()` function instantiates and returns an instance of the
         retries: 1,
         sessionId: (process.pid % 65535),
         timeout: 2000,
-        ttl: 128
+        ttl: 128,
+        dontFrag: false
     };
     
     var session = ping.createSession (options);
@@ -176,6 +177,7 @@ items:
  * `timeout` - Number of milliseconds to wait for a response before re-trying
    or failing, defaults to `2000`
  * `ttl` - Value to use for the IP header time to live field, defaults to `128`
+ * `dontFrag` - Boolean, default false. If don't frag bit is set or not
 
 After creating the ping `Session` object an underlying raw socket will be
 created.  If the underlying raw socket cannot be opened an exception with be

--- a/index.js
+++ b/index.js
@@ -99,6 +99,10 @@ function Session (options) {
 	this.reqsPending = 0;
 
 	this.getSocket ();
+    if (options && options.dontFrag) {
+        var dontFrag = raw.SocketOption.IP_PMTUDISC_DO;
+        this.getSocket().setOption(raw.SocketLevel.IPPROTO_IP, raw.SocketOption.IP_MTU_DISCOVER, dontFrag);
+    }
 };
 
 util.inherits (Session, events.EventEmitter);


### PR DESCRIPTION
Can send ping with DF bit set. Can do PMTUD.

If pull request of raw-socket https://github.com/stephenwvickers/node-raw-socket/pull/11 is merged, can send ping with DF bit set.
Which can be used for PMTUD.
PMTUD is usefully in troubleshooting MTU problems on CPE router.

Please, contact-me if you have question.

Have a nice day.